### PR TITLE
Move version detection offset of Honkers from 4000 to 2000

### DIFF
--- a/games/star-rail/integration.lua
+++ b/games/star-rail/integration.lua
@@ -350,7 +350,7 @@ function v1_game_get_version(game_path, edition)
     return nil
   end
 
-  file:seek("set", 3000)
+  file:seek("set", 2000)
 
   return file:read(10000):gmatch("[1-9]+[.][0-9]+[.][0-9]+")()
 end


### PR DESCRIPTION
Version data of Honkers 2.7.0 lies at 0x08FB, which is 2299 in decimal, way smaller than 4000. This patch sets the detection offset to 2000 in decimal, allowing proper detection. Let's see if things break in 2.8.0 and onwards...