### PR TITLE
docs: fix link to the integrations guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Anime Games Launcher integrations scripts index
 
-Index of games integrations scripts for the [anime games launcher](https://github.com/an-anime-team/anime-games-launcher). Documentation can be found in [here](https://github.com/an-anime-team/anime-games-launcher/blob/master/GAMES_INTEGRATION.md).
+Index of games integrations scripts for the [anime games launcher](https://github.com/an-anime-team/anime-games-launcher).
+Documentation can be found in the [`repository/integrations/` directory](https://github.com/an-anime-team/anime-games-launcher/tree/master/repository/integrations).


### PR DESCRIPTION
## Summary

Fix integrations guide link in the README

## Details

- after https://github.com/an-anime-team/anime-games-launcher/commit/b6412e11896533f03dd38c3cf604043b8d629f52, it moved to the `repository/integrations` directory of the AGL repo

### Misc style changes

- misc grammar: "in here" -> "here"
  - misc style: instead of using an ambiguous "here", say where directly
    - see the [k8s style guide on links](https://kubernetes.io/docs/contribute/style/style-guide/#links) for rationale
- misc formatting: use 1 sentence per line of markdown for ease of diffing
  - in the future, any change to a sentence will only affect one line instead of the entire paragraph
  
## Verification

See the rendered markdown of the branch