### PR TITLE
fix(games/arknights): handle # in url correctly, fix infinite loop in download queue

### DIFF
--- a/games/arknights/integration.luau
+++ b/games/arknights/integration.luau
@@ -105,6 +105,11 @@ end
 
 ----------------------------- game api -----------------------------
 
+-- avoid parsing everything after a `#` symbol as an URL fragment
+local function url_encode_path(file_path: string): string
+    return (file_path:gsub("#", "%%23"))
+end
+
 local __api_auth_header: { [GameEdition]: string } = {}
 
 local function api_get_auth_header(edition: GameEdition): string
@@ -303,8 +308,10 @@ local function get_download_game_pipeline(
 
                     if game_files_info then
                         for _, file_info in pairs(game_files_info.files) do
+                            local file_url_path = url_encode_path(`{game_files_info.source}{file_info.path}`)
+
                             game_files[file_info.path] = {
-                                url = `{GAME_API_INFO[edition].cdn_url}{game_files_info.source}{file_info.path}`,
+                                url = `{GAME_API_INFO[edition].cdn_url}{file_url_path}`,
                                 size = tonumber(file_info.size) or 0
                             }
                         end
@@ -398,6 +405,8 @@ local function get_download_game_pipeline(
                                 and (max_parallel_streams > 0 and queue_count < max_parallel_streams)
                         )
                         do
+                            local queued_file = false
+
                             for file_path, file_info in pairs(game_files) do
                                 queue[file_path] = {
                                     size = file_info.size,
@@ -413,10 +422,13 @@ local function get_download_game_pipeline(
 
                                 game_files[file_path] = nil
 
+                                queued_file = true
+
                                 break
                             end
 
-                            if queue_count == 0 then
+                            -- no files left to queue
+                            if not queued_file then
                                 break
                             end
                         end


### PR DESCRIPTION
Some game files have a `#` symbol in their names. It was being misinterpreted as an URL fragment, leading to a 404 and broken game files. This should probably be handled in the launcher downloader as well but doing it here should work for now.

Also fixed the download queue population loop spinning forever once the last files were queued, which kept the launcher stuck during download.

<img width="1920" height="1033" alt="image" src="https://github.com/user-attachments/assets/80b4a2f6-42f9-4082-a2e1-8280048adbc8" />
